### PR TITLE
0.7.4

### DIFF
--- a/tentacle/__init__.py
+++ b/tentacle/__init__.py
@@ -3,7 +3,7 @@
 import sys
 
 __package__ = "tentacle"
-__version__ = "0.7.3"
+__version__ = "0.7.4"
 
 
 def greeting(string, outputToConsole=True):

--- a/tentacle/slots/maya/display.py
+++ b/tentacle/slots/maya/display.py
@@ -128,10 +128,10 @@ class Display(SlotsMaya):
 
     def b013(self):
         """Explode View GUI"""
-        ui_file = mtk.exploded_view.get_ui_file()
-        slot_class = mtk.exploded_view.ExplodedViewSlots
+        module = mtk.display_utils.exploded_view
+        slot_class = module.ExplodedViewSlots
 
-        self.sb.register(ui_file, slot_class)
+        self.sb.register("exploded_view.ui", slot_class, base_dir=module)
         self.sb.parent().set_ui("exploded_view")
 
     def b021(self):

--- a/tentacle/slots/maya/duplicate.py
+++ b/tentacle/slots/maya/duplicate.py
@@ -40,18 +40,18 @@ class Duplicate(SlotsMaya):
 
     def b006(self):
         """Duplicate Linear"""
-        ui_file = mtk.duplicate_linear.get_ui_file()
-        slot_class = mtk.duplicate_linear.DuplicateLinearSlots
+        module = mtk.edit_utils.duplicate_linear
+        slot_class = module.DuplicateLinearSlots
 
-        self.sb.register(ui_file, slot_class)
+        self.sb.register("duplicate_linear.ui", slot_class, base_dir=module)
         self.sb.parent().set_ui("duplicate_linear")
 
     def b007(self):
         """Duplicate Radial"""
-        ui_file = mtk.duplicate_radial.get_ui_file()
-        slot_class = mtk.duplicate_radial.DuplicateRadialSlots
+        module = mtk.edit_utils.duplicate_radial
+        slot_class = module.DuplicateRadialSlots
 
-        self.sb.register(ui_file, slot_class)
+        self.sb.register("duplicate_radial.ui", slot_class, base_dir=module)
         self.sb.parent().set_ui("duplicate_radial")
 
 

--- a/tentacle/slots/maya/materials.py
+++ b/tentacle/slots/maya/materials.py
@@ -187,7 +187,7 @@ class Materials(SlotsMaya):
     def b005_init(self, widget):
         """ """
         current_material = self.sb.materials.cmb002.currentData()
-        text = f"Assign {current_material}"
+        text = f"Assign: {current_material}"
         widget.setText(text)
         submenu_widget = self.sb.materials_submenu.b005
         submenu_widget.setText(text)

--- a/tentacle/slots/maya/polygons.py
+++ b/tentacle/slots/maya/polygons.py
@@ -177,13 +177,10 @@ class Polygons(SlotsMaya):
 
     def tb004(self, widget):
         """Bevel (Chamfer)"""
-        ui_file = mtk.bevel_edges.get_ui_file()
-        slot_class = mtk.bevel_edges.BevelEdgesSlots
+        module = mtk.edit_utils.bevel_edges
+        slot_class = module.BevelEdgesSlots
 
-        self.sb.register(ui_file, slot_class)
-        # if pm.ls(sl=True):
-        #     self.sb.bevel_edges.set_as_current()
-        #     self.sb.bevel_edges.slots.preview.enable()
+        self.sb.register("bevel_edges.ui", slot_class, base_dir=module)
         self.sb.parent().set_ui("bevel_edges")
 
     def tb005_init(self, widget):


### PR DESCRIPTION
- slots.maya:  update the way external UI files are registered.  The uitk.file_manager now accepts filepaths as a string,  objects such as a package, module, or class in which to derive a filepath from,  or a calling frame as an integer.  for example:  self.sb.register("bevel_edges.ui", slot_class, base_dir=module)  will search the given modules directory for the bevel_edges.ui file.