### PR TITLE
0.9.18

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 [![License: LGPL v3](https://img.shields.io/badge/License-LGPL%20v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0.en.html)
-[![Version](https://img.shields.io/badge/Version-0.9.17-blue.svg)](https://pypi.org/project/tentacletk/)
+[![Version](https://img.shields.io/badge/Version-0.9.18-blue.svg)](https://pypi.org/project/tentacletk/)
 
 # Tentacle: A Python3/PySide2 Marking Menu and DCC Toolkit
 
@@ -53,5 +53,5 @@ For Maya, add a macro to a hotkey similar to the following:
 
 ```python
 from tentacle import tcl_maya
-tcl_maya.show(key_show='Key_Z')  # Change to match your chosen hotkey.
+tcl_maya.show(key_show='Z')  # Change to match your chosen hotkey.
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ PySide2
 shiboken2
 pymel
 pythontk==0.7.12
-uitk==1.0.11
-mayatk==0.9.13
+uitk==1.0.12
+mayatk==0.9.14

--- a/tentacle/__init__.py
+++ b/tentacle/__init__.py
@@ -3,7 +3,7 @@
 import sys
 
 __package__ = "tentacle"
-__version__ = "0.9.17"
+__version__ = "0.9.18"
 
 
 def greeting(string, outputToConsole=True):

--- a/tentacle/slots/__init__.py
+++ b/tentacle/slots/__init__.py
@@ -21,9 +21,9 @@ class Slots(QtCore.QObject):
 
     def __init__(self, parent=None):
         super().__init__(parent)
-        """
-        """
+        """ """
         self.sb = self.switchboard()
+        self.sb.parent().left_mouse_double_click_ctrl.connect(self.repeat_last_command)
 
     def hide_main(fn):
         """A decorator that hides the stacked widget main window."""
@@ -41,6 +41,17 @@ class Slots(QtCore.QObject):
             return result
 
         return wrapper
+
+    def repeat_last_command(self):
+        """Repeat the last stored command."""
+        self.sb.parent().hide()
+        method = self.sb.prev_slot
+
+        if callable(method):
+            widget = self.sb.get_widget_from_method(method)
+            widget.call_slot()
+        else:
+            print("No recent commands in history.")
 
 
 # --------------------------------------------------------------------------------------------

--- a/tentacle/slots/maya/normals.py
+++ b/tentacle/slots/maya/normals.py
@@ -84,7 +84,7 @@ class Normals(SlotsMaya):
         )
 
     def tb001(self, widget):
-        """Harden Edge Normals"""
+        """Set Normals By Angle"""
         angle_threshold = widget.menu.s002.value()
         upper_hardness = widget.menu.s003.value()
         lower_hardness = widget.menu.s004.value()
@@ -105,31 +105,6 @@ class Normals(SlotsMaya):
 
         objects = pm.ls(selection, objectsOnly=True)
         pm.polyOptions(objects, se=soft_edge_display)
-
-    def tb002_init(self, widget):
-        """ """
-        widget.menu.add(
-            "QSpinBox",
-            setPrefix="Angle: ",
-            setObjectName="s000",
-            set_limits=[0, 180],
-            setValue=60,
-            setToolTip="Angle degree.",
-        )
-
-    def tb002(self, widget):
-        """Set Normals By Angle"""
-        normalAngle = widget.menu.s000.value()
-
-        objects = pm.ls(sl=True, objectsOnly=1, flatten=1)
-        for obj in objects:
-            sel = pm.ls(obj, sl=1)
-            pm.polySetToFaceNormal(sel, setUserNormal=1)  # reset to face
-            polySoftEdge = pm.polySoftEdge(
-                sel, angle=normalAngle
-            )  # smooth if angle is lower than specified amount. default:60
-            if len(objects) == 1:
-                return polySoftEdge
 
     def tb003_init(self, widget):
         """ """
@@ -182,11 +157,19 @@ class Normals(SlotsMaya):
         objects = pm.ls(sl=True)
         mtk.average_normals(objects, by_uv_shell=by_uv_shell)
 
-    def b001(self):
+    def b000(self):
         """Soften Edge Normals"""
-        selection = pm.ls(sl=1)
+        selection = pm.ls(sl=True, fl=True)
         if selection:
-            pm.polySoftEdge(selection, angle=180)
+            pm.polySoftEdge(selection, angle=180)  # Use maximum angle to soften
+            pm.select(selection)  # Re-select the original selection
+
+    def b001(self):
+        """Harden all selected edges."""
+        selection = pm.ls(sl=True, fl=True)
+        if selection:
+            pm.polySoftEdge(selection, angle=0)  # Use minimum angle to harden
+            pm.select(selection)  # Re-select the original selection
 
     def b002(self):
         """Transfer Normals"""

--- a/tentacle/ui/normals#submenu.ui
+++ b/tentacle/ui/normals#submenu.ui
@@ -90,9 +90,9 @@
     </property>
     <property name="geometry">
      <rect>
-      <x>360</x>
-      <y>270</y>
-      <width>91</width>
+      <x>435</x>
+      <y>240</y>
+      <width>81</width>
       <height>19</height>
      </rect>
     </property>
@@ -106,7 +106,7 @@
      <string>Harden all creased edges on the selected object.</string>
     </property>
     <property name="text">
-     <string>Harden Edges</string>
+     <string>By Angle</string>
     </property>
     <property name="iconSize">
      <size>
@@ -214,14 +214,14 @@
      </size>
     </property>
    </widget>
-   <widget class="QPushButton" name="b001">
+   <widget class="QPushButton" name="b000">
     <property name="enabled">
      <bool>true</bool>
     </property>
     <property name="geometry">
      <rect>
-      <x>360</x>
-      <y>300</y>
+      <x>370</x>
+      <y>270</y>
       <width>91</width>
       <height>20</height>
      </rect>
@@ -280,6 +280,37 @@
     </property>
     <property name="text">
      <string>Transfer Normals</string>
+    </property>
+    <property name="iconSize">
+     <size>
+      <width>18</width>
+      <height>18</height>
+     </size>
+    </property>
+   </widget>
+   <widget class="PushButton" name="b001">
+    <property name="enabled">
+     <bool>true</bool>
+    </property>
+    <property name="geometry">
+     <rect>
+      <x>370</x>
+      <y>300</y>
+      <width>91</width>
+      <height>19</height>
+     </rect>
+    </property>
+    <property name="maximumSize">
+     <size>
+      <width>999</width>
+      <height>19</height>
+     </size>
+    </property>
+    <property name="toolTip">
+     <string>Harden all creased edges on the selected object.</string>
+    </property>
+    <property name="text">
+     <string>Harden Edges</string>
     </property>
     <property name="iconSize">
      <size>

--- a/tentacle/ui/normals.ui
+++ b/tentacle/ui/normals.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>200</width>
-    <height>334</height>
+    <height>306</height>
    </rect>
   </property>
   <property name="tabShape">
@@ -61,11 +61,14 @@
        </widget>
       </item>
       <item>
-       <widget class="QGroupBox" name="face">
+       <widget class="QGroupBox" name="edge">
         <property name="title">
-         <string>Face</string>
+         <string>Edge</string>
         </property>
-        <layout class="QGridLayout" name="gridLayout">
+        <layout class="QVBoxLayout" name="verticalLayout_5">
+         <property name="spacing">
+          <number>1</number>
+         </property>
          <property name="leftMargin">
           <number>0</number>
          </property>
@@ -78,10 +81,7 @@
          <property name="bottomMargin">
           <number>0</number>
          </property>
-         <property name="spacing">
-          <number>1</number>
-         </property>
-         <item row="6" column="0" colspan="3">
+         <item>
           <widget class="PushButton" name="tb003">
            <property name="enabled">
             <bool>true</bool>
@@ -112,7 +112,7 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="0" colspan="3">
+         <item>
           <widget class="PushButton" name="tb004">
            <property name="enabled">
             <bool>true</bool>
@@ -143,7 +143,7 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="0" colspan="3">
+         <item>
           <widget class="QPushButton" name="b006">
            <property name="enabled">
             <bool>true</bool>
@@ -174,63 +174,8 @@
            </property>
           </widget>
          </item>
-         <item row="3" column="0" colspan="3">
-          <widget class="PushButton" name="tb002">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>20</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>16777215</width>
-             <height>20</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>Set normal angle</string>
-           </property>
-           <property name="text">
-            <string>By Angle</string>
-           </property>
-           <property name="iconSize">
-            <size>
-             <width>18</width>
-             <height>18</height>
-            </size>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item>
-       <widget class="QGroupBox" name="edge">
-        <property name="title">
-         <string>Edge</string>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout_5">
-         <property name="spacing">
-          <number>1</number>
-         </property>
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
          <item>
-          <widget class="QPushButton" name="b001">
+          <widget class="QPushButton" name="b000">
            <property name="enabled">
             <bool>true</bool>
            </property>
@@ -261,7 +206,7 @@
           </widget>
          </item>
          <item>
-          <widget class="PushButton" name="tb001">
+          <widget class="PushButton" name="b001">
            <property name="enabled">
             <bool>true</bool>
            </property>
@@ -282,6 +227,37 @@
            </property>
            <property name="text">
             <string>Harden Edges</string>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>18</width>
+             <height>18</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="PushButton" name="tb001">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>20</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>20</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;Harden edges normals.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If the entire object is selected, all object edges will be used.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>By Angle</string>
            </property>
            <property name="iconSize">
             <size>


### PR DESCRIPTION
- slots.maya.normals:  Updated the normals module separating `soften edges`, `harden edges`, and `by angle`.
- tcl: `key_show` now accepts qt style key names as well as shorhand key naming (ie. "Key_F12" or "F12").  Bugfix a keyboard release issue.
- update requirements.txt